### PR TITLE
pip install still fail

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 recursive-include opencc *.txt *.py
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
         name='opencc-python-reimplemented',
-        version='0.1.1',
+        version='0.1.2',
         description='OpenCC made with Python',
         long_description=readme(),
         url='https://github.com/yichen0831/opencc-python',

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,15 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-cwd = path.abspath(path.dirname(__file__))
-
-with open(path.join(cwd, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
+def readme():
+    with open('README.md') as f:
+        return f.read()
 
 setup(
         name='opencc-python-reimplemented',
         version='0.1.1',
         description='OpenCC made with Python',
-        long_description=long_description,
+        long_description=readme(),
         url='https://github.com/yichen0831/opencc-python',
         author='Yichen Huang (Eugene)',
         author_email='yichen0831@gmail.com',


### PR DESCRIPTION
Sorry, still got the same error

```
root@b1dcb7389a1f:/code# pip3 install -U opencc-python-reimplemented --no-cache-dir
Collecting opencc-python-reimplemented
  Downloading opencc-python-reimplemented-0.1.1.tar.gz (484kB)
    100% |████████████████████████████████| 491kB 2.2MB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-lvqbez7z/opencc-python-reimplemented/setup.py", line 7, in <module>
        with open(path.join(cwd, 'README.md'), encoding='utf-8') as f:
      File "/usr/lib/python3.5/codecs.py", line 895, in open
        file = builtins.open(filename, mode, buffering)
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-build-lvqbez7z/opencc-python-reimplemented/README.md'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-lvqbez7z/opencc-python-reimplemented/

```

I follow [pypi document](http://python-packaging.readthedocs.io/en/latest/metadata.html) to handle this issue

it works for me.