### PR TITLE
Performance Improvement

### DIFF
--- a/opencc/opencc.py
+++ b/opencc/opencc.py
@@ -90,7 +90,7 @@ class OpenCC:
         """
         tree = StringTree(string)
         for c_dict in dictionary:
-            if isinstance(c_dict, dict):
+            if isinstance(c_dict, tuple):
                 tree.convert_tree(c_dict)
                 if not is_dict_group:
                     # Don't reform the string here if the dictionary list is part of a group
@@ -134,12 +134,15 @@ class OpenCC:
             else:
                 if not item in self.dict_cache:
                     map_dict = {}
+                    max_len = 1
                     with io.open(item, "r", encoding="utf-8") as f:
                         for line in f:
                             key, value = line.strip().split('\t')
                             map_dict[key] = value
-                    chain_data.append(map_dict)
-                    self.dict_cache[item] = map_dict
+                            if len(key) > max_len:
+                                max_len = len(key)
+                    chain_data.append((max_len, map_dict))
+                    self.dict_cache[item] = (max_len, map_dict)
                 else:
                     chain_data.append(self.dict_cache[item])
 
@@ -192,8 +195,8 @@ class StringTree:
         right against test_dict. If an entry is found, place the remaining
         string portion on the left and right into sub-trees and recurively
         convert each.
-        :param test_dict: the dict currently being applied againt
-                        the string
+        :param test_dict: a tuple of the max key length and dict currently being
+                          applied against the string
         :return: None
         """
         if self.matched == True:
@@ -202,11 +205,11 @@ class StringTree:
             if self.right is not None:
                 self.right.convert_tree(test_dict)
         else:
-            test_len = self.string_len
+            test_len = min (self.string_len, test_dict[0])
             while test_len != 0:
                 # Loop through trying successively smaller substrings in the dictionary
                 for i in range(0, self.string_len - test_len + 1):
-                    if self.string[i:i+test_len] in test_dict:
+                    if self.string[i:i+test_len] in test_dict[1]:
                         # Match found.
                         if i > 0:
                             # Put everything to the left of the match into the left sub-tree and further process it
@@ -217,7 +220,7 @@ class StringTree:
                             self.right = StringTree(self.string[i+test_len:])
                             self.right.convert_tree(test_dict)
                         # Save the dictionary value in this tree
-                        value = test_dict[self.string[i:i+test_len]]
+                        value = test_dict[1][self.string[i:i+test_len]]
                         if len(value.split(' ')) > 1:
                             # multiple mapping, use the first one for now
                             value = value.split(' ')[0]

--- a/test/conversion_test.py
+++ b/test/conversion_test.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+
+# Uncomment out the following line if using python 2.7; also modify first line is on *NIX system
+#from __future__ import (unicode_literals, division, absolute_import, print_function)
+
 import sys
 import os
 import unittest
@@ -8,7 +12,10 @@ import unittest
 class OpenCCTest(unittest.TestCase):
 
     def setUp(self):
+        # Unitialized convertor object
         self.openCC = OpenCC()
+        # Constructor intitialized convertor object
+        self.openCC2 = OpenCC('hk2s')
 
     def test_hk2s(self):
         self.openCC.set_conversion('hk2s')
@@ -60,6 +67,55 @@ class OpenCCTest(unittest.TestCase):
         words = '香菸（英語：Cigarette），為菸草製品的一種。記憶體是一種很常見及常用的電腦輸入裝置。'
         self.assertEqual(self.openCC.convert(words), '香烟（英语：Cigarette），为烟草制品的一种。内存是一种很常见及常用的电脑输入设备。')
 
+    # Code coverage and edge condition tests
+
+    def test_unset(self):
+        try:
+            words = '香菸（英語：Cigarette），為菸草製品的一種。記憶體是一種很常見及常用的電腦輸入裝置。'
+            self.openCC.convert(words)
+            #Following line not hit due to exception in conversion
+            self.assertTrue(False) # pragma: no cover
+        except ValueError:
+            pass
+
+    def test_hk2s_convert2(self):
+        self.openCC.set_conversion('hk2s')
+        words = '香煙（英語：Cigarette），為煙草製品的一種。滑鼠是一種很常見及常用的電腦輸入設備。'
+        self.assertEqual(self.openCC2.convert(words), '香烟（英语：Cigarette），为烟草制品的一种。滑鼠是一种很常见及常用的电脑输入设备。')
+  
+    def test_multiple_conversions(self):
+        self.openCC.set_conversion('hk2s')
+        words_t = '香煙（英語：Cigarette），為煙草製品的一種。滑鼠是一種很常見及常用的電腦輸入設備。'
+        self.assertEqual(self.openCC.convert(words_t), '香烟（英语：Cigarette），为烟草制品的一种。滑鼠是一种很常见及常用的电脑输入设备。')
+        self.openCC.set_conversion('s2t')
+        words_s = '香烟（英语：Cigarette），为烟草制品的一种。鼠标是一种很常见及常用的电脑输入设备。'
+        self.assertEqual(self.openCC.convert(words_s), '香菸（英語：Cigarette），爲菸草製品的一種。鼠標是一種很常見及常用的電腦輸入設備。')
+        self.openCC.set_conversion('hk2s')
+        self.assertEqual(self.openCC.convert(words_t), '香烟（英语：Cigarette），为烟草制品的一种。滑鼠是一种很常见及常用的电脑输入设备。')
+        self.openCC.set_conversion('hk2s')
+        self.assertEqual(self.openCC.convert(words_t), '香烟（英语：Cigarette），为烟草制品的一种。滑鼠是一种很常见及常用的电脑输入设备。')
+
+    def test_t2s_extended_unicode_1(self):
+        self.openCC.set_conversion('t2s')
+        words = '𠁞'
+        self.assertEqual(self.openCC.convert(words), '𠀾')
+
+    def test_t2s_extended_unicode_2(self):
+        self.openCC.set_conversion('t2s')
+        words = '𠁞種'
+        self.assertEqual(self.openCC.convert(words), '𠀾种')
+
+    def test_t2s_empty(self):
+        self.openCC.set_conversion('t2s')
+        words = ''
+        self.assertEqual(self.openCC.convert(words), '')
+
+    def test_t2s_choose_first_available(self):
+        # TSCharacters.txt gives two choices for 儘: 尽 侭
+        # The first one, 尽, is chosen
+        self.openCC.set_conversion('t2s')
+        words = '儘'
+        self.assertEqual(self.openCC.convert(words), '尽')
 
 if __name__ == '__main__':
     sys.path.append(os.pardir)


### PR DESCRIPTION
Determine max key length in each conversion dictionary.
To save time, when looking for a match in a string, only use sub-strings
that are equal or less than the max possible length.
~25% speed improvement when converting 魯迅︰吶喊 from traditional to
simplified; verified output text identical to original code. Tested on
python 2.7 and 3.7.

Add tests to achieve 100% code coverage.