### PR TITLE
Add support for Python 2.6 and 2.7

### DIFF
--- a/opencc/__main__.py
+++ b/opencc/__main__.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import argparse
 import sys
+import io
 from opencc import OpenCC
 
 
@@ -12,8 +13,8 @@ def main():
                         help='Read original text from <file>.')
     parser.add_argument('-o', '--output', metavar='<file>',
                         help='Write converted text to <file>.')
-    parser.add_argument('-c', '--config', metavar='<file>',
-                        help='Configuration file')
+    parser.add_argument('-c', '--config', metavar='<conversion>',
+                        help='Conversion')
     parser.add_argument('--in-enc', metavar='<encoding>', default='UTF-8',
                         help='Encoding for input')
     parser.add_argument('--out-enc', metavar='<encoding>', default='UTF-8',
@@ -21,15 +22,15 @@ def main():
     args = parser.parse_args()
 
     if args.config is None:
-        print("Please specify a configuration file.", file=sys.stderr)
+        print("Please specify a conversion.", file=sys.stderr)
         return 1
 
     cc = OpenCC(args.config)
 
-    with open(args.input if args.input else 0, encoding=args.in_enc) as f:
+    with io.open(args.input if args.input else 0, encoding=args.in_enc) as f:
         input_str = f.read()
     output_str = cc.convert(input_str)
-    with open(args.output if args.output else 1, 'w',
+    with io.open(args.output if args.output else 1, 'w',
               encoding=args.out_enc) as f:
         f.write(output_str)
 


### PR DESCRIPTION
During command line operation, remove the following error when using Python 2.6 and 2.7:
  "TypeError: 'encoding' is an invalid keyword argument for this function"

Use the 'io' module common to both Python versions to remove the 2.6 TypeError.
Python 3 operation is unchanged.

Also made a slight clarification to the command line usage text.