### PR TITLE
fixed: TypeError: 'encoding' is an invalid keyword argument for this …

### DIFF
--- a/opencc/__main__.py
+++ b/opencc/__main__.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import argparse
 import sys
+import io
 from opencc import OpenCC
 
 
@@ -26,10 +27,10 @@ def main():
 
     cc = OpenCC(args.config)
 
-    with open(args.input if args.input else 0, encoding=args.in_enc) as f:
+    with io.open(args.input if args.input else 0, encoding=args.in_enc) as f:
         input_str = f.read()
     output_str = cc.convert(input_str)
-    with open(args.output if args.output else 1, 'w',
+    with io.open(args.output if args.output else 1, 'w',
               encoding=args.out_enc) as f:
         f.write(output_str)
 


### PR DESCRIPTION
Fixed the below error while invoking opencc from command line:

python -m opencc -c t2s --in-enc utf-8 --out-enc ascii -i ~/1 -o my_traditional_output_file.txt
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Library/Python/2.7/site-packages/opencc/__main__.py", line 40, in <module>
    sys.exit(main())
  File "/Library/Python/2.7/site-packages/opencc/__main__.py", line 29, in main
    with open(args.input if args.input else 0, encoding=args.in_enc) as f:
